### PR TITLE
Update contribution guide to mention the scope of pull requests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -99,7 +99,7 @@ The following are examples of good commit messages:
 Please refer to [Conventional Commits](https://conventionalcommits.org/) for a detailed guide on how to structure commit messages. Writing good, detailed, commit messages helps ensure that we can refer back to the git history and quickly find where specific changes occurred in the event that they need further review, reverting, etc.
 
 # Pull Requests
-As stated in [Making Issues](#making-issues), before making a pull request there must be an open, approved, issue for the changes being made. If you can not find an approved issue for the changes you wish to make, please make one before continuing.
+As stated in [Making Issues](#making-issues), before making a pull request there must be an open, approved, issue for the changes being made. If you can not find an approved issue for the changes you wish to make, please make one before continuing. Unless a single update closes multiple issues, each pull request should target a single issue. If you wish to work on multiple issues, please open a pull request for each. This keeps the pull request scope limited and allows for easier discussion of the individual issues and your related changes to them.
 
 Before making a pull request ensure you have tested all changes and that no regressions have been introduced.
 


### PR DESCRIPTION
### Changes:

Updates the `Pull Requests` section to mention the scope of pull requests. The goal of this is to prevent pull requests like https://github.com/PretendoNetwork/Volbeat/pull/3 in the future, where a single pull request attempts to target multiple unrelated issues.

The example pull request is not a huge issue, just using it as an example as the first one I saw. However for bigger pull requests, with many other changes, it *can* become an issue. The goal is to limit the scope of a pull request so that the specific changes for the issue it's targeting can be discussed individually, rather than trying to mix multiple conversations.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.