### PR TITLE
Add missing legal warning to `Prerequisites` section in the contribution guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,8 +18,13 @@ Thank you for showing interest in contributing to Pretendo Network! As an open s
 
 # Prerequisites
 > [!CAUTION]
-> You may only contribute to Pretendo Network if you are legally able to do so. Being a part of the Nintendo Developer program, being under any other related NDA, having access to any related SDKs legally obtained or not, etc. prohibits you from contributing to Pretendo Network. If it is discovered that you are a part of these programs, are under any related NDA, have access to any related SDKs legally obtained or not, etc. you will immediately be blocked from the organization, even if you never use any information in contributions or don't even use the mentioned tools.
-
+> By contributing to this project, you agree to the following:  
+>
+> 1. **Developer Certificate of Origin** – All contributions must comply with the [Developer Certificate of Origin](https://developercertificate.org/).  
+> 2. **Ownership & Rights** – You may only contribute content you own. Do not submit anything that is:  
+>    - Owned by someone else (unless properly licensed for this project).  
+>    - A trade secret, under NDA, or otherwise confidential.  
+> 3. **Respect for Nintendo’s IP** – We strictly avoid infringing on Nintendo’s intellectual property. If you have had access to Nintendo’s proprietary materials (legally or otherwise), we may take steps to ensure compliance, including blocking contributions or removing existing ones.  
 Before diving into the contribution process, we recommend familiarizing yourself with our project's existing repositories. By studying our existing codebases, issues, and pull requests you will get a better sense of direction of how we operate. Additionally, please review our [Code of Conduct](CODE_OF_CONDUCT.md) to ensure a respectful and inclusive environment for all participants.
 
 Given that our project's main goal is to emulate Nintendo Network, it is also highly recommended that you familiarize yourself with how these services operate. Information on these topics, and our libraries, can be found both on our [wiki](https://nintendo-wiki.pretendo.network/docs/) and our (in progress) [developer documentation](https://developer.pretendo.network/home).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,6 +17,9 @@ Thank you for showing interest in contributing to Pretendo Network! As an open s
 - [Licensing](#licensing)
 
 # Prerequisites
+> [!CAUTION]
+> You may only contribute to Pretendo Network if you are legally able to do so. Being a part of the Nintendo Developer program, being under any other related NDA, having access to any related SDKs legally obtained or not, etc. prohibits you from contributing to Pretendo Network. If it is discovered that you are a part of these programs, are under any related NDA, have access to any related SDKs legally obtained or not, etc. you will immediately be blocked from the organization, even if you never use any information in contributions or don't even use the mentioned tools.
+
 Before diving into the contribution process, we recommend familiarizing yourself with our project's existing repositories. By studying our existing codebases, issues, and pull requests you will get a better sense of direction of how we operate. Additionally, please review our [Code of Conduct](CODE_OF_CONDUCT.md) to ensure a respectful and inclusive environment for all participants.
 
 Given that our project's main goal is to emulate Nintendo Network, it is also highly recommended that you familiarize yourself with how these services operate. Information on these topics, and our libraries, can be found both on our [wiki](https://nintendo-wiki.pretendo.network/docs/) and our (in progress) [developer documentation](https://developer.pretendo.network/home).


### PR DESCRIPTION
Resolves #XXX

### Changes:

Adds a missing warning in the `Prerequisites` section of the contribution guide to say the obvious; anyone under an NDA cannot contribute to us

We have not had any SDK/NDA info come into the project, but this warning was missing when it should have been there ages ago and really just covers our ass since Nintendo has been kinda aggressive lately. It explicitly states that we prohibit contributions from users under an NDA or have access to any SDK, and that if found we will block future contributions as a way to cover our asses and to tell Nintendo (and others) that we have a firm stance against this

This is effectively the same stance projects like Wine have:

- https://gitlab.winehq.org/wine/wine/-/wikis/Developer-FAQ#copyright-issues
- https://gitlab.winehq.org/wine/wine/-/wikis/Developer-FAQ#would-documenting-windows-code-help

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.